### PR TITLE
Cross platform image serialization

### DIFF
--- a/Echo.Core/Echo.Core.csproj
+++ b/Echo.Core/Echo.Core.csproj
@@ -18,6 +18,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Magick.NET-Q16-HDRI-AnyCPU" Version="12.2.2" />
         <PackageReference Include="System.Drawing.Common" Version="5.0.3" />
         <ProjectReference Include="..\Echo.Generation\Echo.Generation.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>

--- a/Echo.Core/Echo.Core.csproj
+++ b/Echo.Core/Echo.Core.csproj
@@ -19,7 +19,6 @@
 
     <ItemGroup>
         <PackageReference Include="Magick.NET-Q16-HDRI-AnyCPU" Version="12.2.2" />
-        <PackageReference Include="System.Drawing.Common" Version="5.0.3" />
         <ProjectReference Include="..\Echo.Generation\Echo.Generation.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
 

--- a/Echo.Core/src/InOut/EchoDescription/LiteralParser.cs
+++ b/Echo.Core/src/InOut/EchoDescription/LiteralParser.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using Echo.Core.Common;
 using Echo.Core.Common.Packed;
+using Echo.Core.InOut.Images;
 using Echo.Core.InOut.Models;
 using Echo.Core.Scenic.Geometries;
 using Echo.Core.Textures;
@@ -32,7 +33,7 @@ static class LiteralParser
 		AddTryParser<RGBA128>(RGBA128.TryParse);
 		AddTryParser<RGB128>(RGBA128.TryParse);
 
-		AddPathTryParser<Texture>(path => TextureGrid.Load<RGB128>(path));
+		AddPathTryParser<Texture>(path => TextureGrid.Load<RGBA128>(path));
 		AddPathTryParser<ITriangleSource>(path => new FileTriangleSource(path));
 		AddParser(span => span);
 

--- a/Echo.Core/src/InOut/Images/Serializer.cs
+++ b/Echo.Core/src/InOut/Images/Serializer.cs
@@ -40,15 +40,14 @@ public abstract record Serializer
 
 		return new string(span) switch //OPTIMIZE: switch on Span with dotnet 7
 		{
-			"png"  => SystemSerializer.png,
-			"jpeg" => SystemSerializer.jpeg,
-			"jpg"  => SystemSerializer.jpeg,
-			"tiff" => SystemSerializer.tiff,
-			"bmp"  => SystemSerializer.bmp,
-			"gif"  => SystemSerializer.gif,
-			"exif" => SystemSerializer.exif,
-			"fpi"  => FpiSerializer.fpi,
-			_      => null
+			"png" => MagickSerializer.png,
+			"jpeg" => MagickSerializer.jpeg,
+			"jpg" => MagickSerializer.jpeg,
+			"tiff" => MagickSerializer.tiff,
+			"exr" => MagickSerializer.exr,
+			"hdr" => MagickSerializer.hdr,
+			"fpi" => FpiSerializer.fpi,
+			_ => null
 		};
 	}
 }

--- a/Echo.Core/src/Scenic/Lights/AmbientLight.cs
+++ b/Echo.Core/src/Scenic/Lights/AmbientLight.cs
@@ -1,3 +1,4 @@
+using System;
 using Echo.Core.Aggregation.Preparation;
 using Echo.Core.Aggregation.Primitives;
 using Echo.Core.Common.Diagnostics;
@@ -49,7 +50,7 @@ public class AmbientLight : InfiniteLight
 		worldToLocal = localToWorld.Inverse;
 
 		//Calculate power
-		float radius = scene.accelerator.SphereBound.radius;
+		float radius = Math.Max(scene.accelerator.SphereBound.radius, 0.1f);
 		float multiplier = Scalars.Pi * radius * radius;
 		_power = multiplier * Texture.Average.Luminance;
 	}

--- a/Echo.UnitTests/Textures/ColorConverterTests.cs
+++ b/Echo.UnitTests/Textures/ColorConverterTests.cs
@@ -9,9 +9,9 @@ using NUnit.Framework;
 namespace Echo.UnitTests.Textures;
 
 [TestFixture]
-public class SystemSerializerTests
+public class ColorConverterTests
 {
-	static SystemSerializerTests()
+	static ColorConverterTests()
 	{
 		inputs.Add(Float4.Zero);
 		inputs.Add(Float4.One);
@@ -37,7 +37,7 @@ public class SystemSerializerTests
 		float expectZ = LinearToGammaExact(input.Z);
 		float expectW = input.W;
 
-		Float4 output = SystemSerializer.LinearToGamma(input);
+		Float4 output = ColorConverter.LinearToGamma(input);
 
 		Assert.That(output >= Float4.Zero);
 		Assert.That(output <= Float4.One);
@@ -57,7 +57,7 @@ public class SystemSerializerTests
 		float expectZ = GammaToLinearExact(input.Z);
 		float expectW = input.W;
 
-		Float4 output = SystemSerializer.GammaToLinear(input);
+		Float4 output = ColorConverter.GammaToLinear(input);
 
 		Assert.That(output >= Float4.Zero);
 		Assert.That(output <= Float4.One);

--- a/Echo.UnitTests/Textures/SystemSerializerTests.cs
+++ b/Echo.UnitTests/Textures/SystemSerializerTests.cs
@@ -29,7 +29,6 @@ public class SystemSerializerTests
 
 	static readonly List<Float4> inputs = new();
 
-
 	[Test]
 	public void LinearToGamma([ValueSource(nameof(inputs))] Float4 input)
 	{
@@ -62,7 +61,7 @@ public class SystemSerializerTests
 
 		Assert.That(output >= Float4.Zero);
 		Assert.That(output <= Float4.One);
-		
+
 		const float Threshold = 0.004f;
 		Assert.That(output.X, FastMath.AlmostZero(expectX) ? Utility.AlmostZero() : Is.EqualTo(expectX).Roughly(Threshold));
 		Assert.That(output.Y, FastMath.AlmostZero(expectY) ? Utility.AlmostZero() : Is.EqualTo(expectY).Roughly(Threshold));

--- a/Echo.UserInterface/src/Core/Areas/ViewerUI.cs
+++ b/Echo.UserInterface/src/Core/Areas/ViewerUI.cs
@@ -220,7 +220,7 @@ public sealed partial class ViewerUI : AreaUI
 		{
 			color = ApproximateSqrt(color.Max(Float4.Zero));
 			color = color.Min(Float4.One) * byte.MaxValue;
-			return SystemSerializer.GatherBytes(Sse2.ConvertToVector128Int32(color.v).AsUInt32());
+			return ColorConverter.GatherBytes(Sse2.ConvertToVector128Int32(color.v).AsUInt32());
 
 			static Float4 ApproximateSqrt(in Float4 value)
 			{


### PR DESCRIPTION
**What is the reason for this pull request?**
Finally removed `System.Drawing.Common` and replaced it with ImageMagick.

**What was added, removed or changed in this pull request?**
Since ImageMagick has cross platform support, we no longer have to use the janky `System.Drawing.Common` that was deprecated for dotnet 6. Along with that, HDR image formats like `.exr` and `.hdr` files are also supported for serialization and deserialization.

**Contributors**
@GaryHuan9 
